### PR TITLE
SHERLOCK: Replace scumm_stricmp() with equalsIgnoreCase()

### DIFF
--- a/engines/sherlock/inventory.cpp
+++ b/engines/sherlock/inventory.cpp
@@ -132,7 +132,7 @@ void Inventory::loadGraphics() {
  */
 int Inventory::findInv(const Common::String &name) {
 	for (int idx = 0; idx < (int)_names.size(); ++idx) {
-		if (scumm_stricmp(name.c_str(), _names[idx].c_str()) == 0)
+		if (name.equalsIgnoreCase(_names[idx]))
 			return idx;
 	}
 
@@ -389,7 +389,7 @@ int Inventory::putNameInInventory(const Common::String &name) {
 
 	for (uint idx = 0; idx < scene._bgShapes.size(); ++idx) {
 		Object &o = scene._bgShapes[idx];
-		if (scumm_stricmp(name.c_str(), o._name.c_str()) == 0 && o._type != INVALID) {
+		if (name.equalsIgnoreCase(o._name) && o._type != INVALID) {
 			putItemInInventory(o);
 			++matches;
 		}
@@ -411,13 +411,13 @@ int Inventory::putItemInInventory(Object &obj) {
 		_vm->setFlags(obj._pickupFlag);
 
 	for (int useNum = 0; useNum < 4; ++useNum) {
-		if (scumm_stricmp(obj._use[useNum]._target.c_str(), "*PICKUP*") == 0) {
+		if (obj._use[useNum]._target.equalsIgnoreCase("*PICKUP*")) {
 			pickupFound = true;
 
 			for (int namesNum = 0; namesNum < 4; ++namesNum) {
 				for (uint bgNum = 0; bgNum < scene._bgShapes.size(); ++bgNum) {
 					Object &bgObj = scene._bgShapes[bgNum];
-					if (scumm_stricmp(obj._use[useNum]._names[namesNum].c_str(), bgObj._name.c_str()) == 0) {
+					if (obj._use[useNum]._names[namesNum].equalsIgnoreCase(bgObj._name)) {
 						copyToInventory(bgObj);
 						if (bgObj._pickupFlag)
 							_vm->setFlags(bgObj._pickupFlag);
@@ -485,7 +485,7 @@ int Inventory::deleteItemFromInventory(const Common::String &name) {
 	int invNum = -1;
 
 	for (int idx = 0; idx < (int)size() && invNum == -1; ++idx) {
-		if (scumm_stricmp(name.c_str(), (*this)[idx]._name.c_str()) == 0)
+		if (name.equalsIgnoreCase((*this)[idx]._name))
 			invNum = idx;
 	}
 

--- a/engines/sherlock/people.cpp
+++ b/engines/sherlock/people.cpp
@@ -620,7 +620,7 @@ int People::findSpeaker(int speaker) {
 		if (obj._type == ACTIVE_BG_SHAPE) {
 			Common::String name(obj._name.c_str(), obj._name.c_str() + 4);
 
-			if (scumm_stricmp(PORTRAITS[speaker], name.c_str()) == 0
+			if (name.equalsIgnoreCase(PORTRAITS[speaker])
 				&& obj._name[4] >= '0' && obj._name[4] <= '9')
 				return idx;
 		}

--- a/engines/sherlock/saveload.cpp
+++ b/engines/sherlock/saveload.cpp
@@ -441,7 +441,7 @@ bool SaveManager::getFilename(int slot) {
 	screen.buttonPrint(Common::Point(ENV_POINTS[5][2], CONTROLS_Y), COMMAND_NULL, true, "Quit");
 
 	Common::String saveName = _savegames[slot];
-	if (scumm_stricmp(saveName.c_str(), "-EMPTY-") == 0) {
+	if (saveName.equalsIgnoreCase("-EMPTY-")) {
 		// It's an empty slot, so start off with an empty save name
 		saveName = "";
 

--- a/engines/sherlock/scene.cpp
+++ b/engines/sherlock/scene.cpp
@@ -617,8 +617,7 @@ void Scene::checkSceneFlags(bool flag) {
 void Scene::checkInventory() {
 	for (uint shapeIdx = 0; shapeIdx < _bgShapes.size(); ++shapeIdx) {
 		for (int invIdx = 0; invIdx < _vm->_inventory->_holdings; ++invIdx) {
-			if (scumm_stricmp(_bgShapes[shapeIdx]._name.c_str(),
-				(*_vm->_inventory)[invIdx]._name.c_str()) == 0) {
+			if (_bgShapes[shapeIdx]._name.equalsIgnoreCase((*_vm->_inventory)[invIdx]._name)) {
 				_bgShapes[shapeIdx]._type = INVALID;
 				break;
 			}
@@ -757,7 +756,7 @@ int Scene::toggleObject(const Common::String &name) {
 	int count = 0;
 
 	for (uint idx = 0; idx < _bgShapes.size(); ++idx) {
-		if (scumm_stricmp(name.c_str(), _bgShapes[idx]._name.c_str()) == 0) {
+		if (name.equalsIgnoreCase(_bgShapes[idx]._name)) {
 			++count;
 			_bgShapes[idx].toggleHidden();
 		}

--- a/engines/sherlock/talk.cpp
+++ b/engines/sherlock/talk.cpp
@@ -1160,7 +1160,7 @@ void Talk::doScript(const Common::String &script) {
 				// Scan for object
 				int objId = -1;
 				for (uint idx = 0; idx < scene._bgShapes.size(); ++idx) {
-					if (scumm_stricmp(tempString.c_str(), scene._bgShapes[idx]._name.c_str()) == 0)
+					if (tempString.equalsIgnoreCase(scene._bgShapes[idx]._name))
 						objId = idx;
 				}
 				if (objId == -1)
@@ -1372,7 +1372,7 @@ void Talk::doScript(const Common::String &script) {
 
 				for (uint idx = 0; idx < scene._bgShapes.size(); ++idx) {
 					Object &object = scene._bgShapes[idx];
-					if (scumm_stricmp(tempString.c_str(), object._name.c_str()) == 0) {
+					if (tempString.equalsIgnoreCase(object._name)) {
 						// Only toggle the object if it's not in the desired state already
 						if ((object._type == HIDDEN && state) || (object._type != HIDDEN && !state))
 							object.toggleHidden();

--- a/engines/sherlock/user_interface.cpp
+++ b/engines/sherlock/user_interface.cpp
@@ -2177,17 +2177,17 @@ void UserInterface::checkUseAction(const UseType *use, const Common::String &inv
 	int targetNum = -1;
 	if (giveMode) {
 		for (int idx = 0; idx < 4 && targetNum == -1; ++idx) {
-			if ((scumm_stricmp(use[idx]._target.c_str(), "*GIVE*") == 0 || scumm_stricmp(use[idx]._target.c_str(), "*GIVEP*") == 0)
-					&& scumm_stricmp(use[idx]._names[0].c_str(), invName.c_str()) == 0) {
+			if ((use[idx]._target.equalsIgnoreCase("*GIVE*") || use[idx]._target.equalsIgnoreCase("*GIVEP*"))
+					&& use[idx]._names[0].equalsIgnoreCase(invName)) {
 				// Found a match
 				targetNum = idx;
-				if (scumm_stricmp(use[idx]._target.c_str(), "*GIVE*") == 0)
+				if (use[idx]._target.equalsIgnoreCase("*GIVE*"))
 					inv.deleteItemFromInventory(invName);
 			}
 		}
 	} else {
 		for (int idx = 0; idx < 4 && targetNum == -1; ++idx) {
-			if (scumm_stricmp(use[idx]._target.c_str(), invName.c_str()) == 0)
+			if (use[idx]._target.equalsIgnoreCase(invName))
 				targetNum = idx;
 		}
 	}


### PR DESCRIPTION
Hi,

I've made some clean up changes, replacing all uses of scumm_stricmp() with .equalsIgnoreCase() in the sherlock engine.