### PR TITLE
Ags

### DIFF
--- a/engines/ags/engine/media/audio/audio.cpp
+++ b/engines/ags/engine/media/audio/audio.cpp
@@ -277,7 +277,7 @@ static void audio_update_polled_stuff() {
 
 	if (play.crossfading_out_channel > 0) {
 		SOUNDCLIP *ch = lock.GetChannel(play.crossfading_out_channel);
-		int newVolume = ch ? ch->get_volume() - play.crossfade_out_volume_per_step : 0;
+		int newVolume = ch ? ch->get_volume_percent() - play.crossfade_out_volume_per_step : 0;
 		if (newVolume > 0) {
 			AudioChannel_SetVolume(&scrAudioChannel[play.crossfading_out_channel], newVolume);
 		} else {
@@ -291,7 +291,7 @@ static void audio_update_polled_stuff() {
 
 	if (play.crossfading_in_channel > 0) {
 		SOUNDCLIP *ch = lock.GetChannel(play.crossfading_in_channel);
-		int newVolume = ch ? ch->get_volume() + play.crossfade_in_volume_per_step : 0;
+		int newVolume = ch ? ch->get_volume_percent() + play.crossfade_in_volume_per_step : 0;
 		if (newVolume > play.crossfade_final_volume_in) {
 			newVolume = play.crossfade_final_volume_in;
 		}

--- a/engines/ags/engine/media/audio/soundclip.h
+++ b/engines/ags/engine/media/audio/soundclip.h
@@ -91,6 +91,9 @@ struct SOUNDCLIP {
 	inline void set_volume_percent(int volume) {
 		set_volume((volume * 255) / 100);
 	}
+	inline int get_volume_percent() const {
+		return get_volume() * 100 / 255;
+	}
 	void adjust_volume();
 	int play_from(int position);
 

--- a/engines/ags/engine/media/video/video.cpp
+++ b/engines/ags/engine/media/video/video.cpp
@@ -52,6 +52,9 @@ namespace AGS3 {
 using AGS::Shared::AssetManager;
 
 void play_theora_video(const char *name, int skip, int flags) {
+#if !defined (USE_THEORADEC)
+	Display("This games uses Theora videos but ScummVM has been compiled without Theora support");
+#else
 	std::unique_ptr<Stream> video_stream(AssetManager::OpenAsset(name));
 	if (!video_stream) {
 		Display("Unable to load theora video '%s'", name);
@@ -120,7 +123,9 @@ void play_theora_video(const char *name, int skip, int flags) {
 	}
 
 	invalidate_screen();
+#endif
 }
+
 void play_flc_file(int numb, int playflags) {
 	warning("TODO: play_flc_file");
 }


### PR DESCRIPTION
A couple of simple fixes.

I am not completely confident with the second one, so it might be worth reviewing. Without that change `AudioChannel_SetVolume()` was asserting as it expects a volume between 0 and 100 but we used values between 0 and 255. My doubts are on whether the `play.crossfade_out_volume_per_step ` and `play.crossfade_in_volume_per_step ` are scaled for a [0, 100] or [0, 255] volume range. I assumed the former so converts the volume to a percent before substracting/adding those.